### PR TITLE
Modify GetIterator to return a generator

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -794,14 +794,27 @@ class Map implements \Countable, Arrayable, Jsonable, \ArrayAccess, \IteratorAgg
     // implements \IteratorAggregate
 
     /**
-     * Get an iterator for a copy of the map.
+     * Get an iterator for the map.
      *
-     * @return \ArrayIterator
+     * @return \Traversable
      * @api
      */
     public function getIterator()
     {
-        return new \ArrayIterator($this->toArray());
+        return (function () {
+            $keys  = $this->keys();
+            $count = count($keys);
+            $index = 0;
+
+            while ($index < $count) {
+                $key   = $keys[$index];
+                $value = $this->get($key);
+
+                yield $key => $value;
+
+                $index++;
+            }
+        })();
     }
 
 
@@ -963,7 +976,8 @@ class Map implements \Countable, Arrayable, Jsonable, \ArrayAccess, \IteratorAgg
     {
         for (end($this->array); null !== ($hash = key($this->array)); prev($this->array)) {
             $key   = $this->hash_to_key($hash);
-            $value =& current($this->array);
+            $current = current($this->array);
+            $value =& $current;
             if (! $this->passes($this->call($code, $value, $key))) {
                 break;
             }

--- a/src/Map.php
+++ b/src/Map.php
@@ -796,25 +796,23 @@ class Map implements \Countable, Arrayable, Jsonable, \ArrayAccess, \IteratorAgg
     /**
      * Get an iterator for the map.
      *
-     * @return \Traversable
+     * @return \Generator
      * @api
      */
     public function getIterator()
     {
-        return (function () {
-            $keys  = $this->keys();
-            $count = count($keys);
-            $index = 0;
+        $keys  = $this->keys();
+        $count = count($keys);
+        $index = 0;
 
-            while ($index < $count) {
-                $key   = $keys[$index];
-                $value = $this->get($key);
+        while ($index < $count) {
+            $key   = $keys[$index];
+            $value = $this->get($key);
 
-                yield $key => $value;
+            yield $key => $value;
 
-                $index++;
-            }
-        })();
+            $index++;
+        }
     }
 
 

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -337,10 +337,29 @@ class MapTest extends \PHPUnit_Framework_TestCase
         $a = [ 'a', 'b' ];
         $c = new Map($a);
         $i = $c->getIterator();
-        $this->assertInstanceOf('\ArrayIterator', $i);
-        $this->assertEquals($a, $i->getArrayCopy());
+        $this->assertInstanceOf('\Traversable', $i);
+
+        $count = 0;
+        foreach ($c as $key => $value) {
+            $this->assertEquals($a[$key], $value);
+            $count++;
+        }
+
+        $this->assertEquals(count($a), $count);
     }
 
+    public function test_iterator_mutation()
+    {
+        $values = [
+            'a' => new Map(),
+            'b' => new Map(),
+        ];
+        $map = new Map($values);
+
+        foreach ($map as $value) {
+            $this->assertInstanceOf(Map::class, $value);
+        }
+    }
 
     // -=-= Data Providers =-=-
 

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -361,6 +361,29 @@ class MapTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function test_non_scalar_keys()
+    {
+        $mapA = new Map();
+        $mapB = new Map([
+            'a' => 1
+        ]);
+        $mapC = new Map([
+            'b' => 2
+        ]);
+
+        $mapA->set($mapB, $mapC);
+
+        foreach ($mapA as $key => $value) {
+            $this->assertEquals($key, $mapB);
+            $this->assertNotEquals($key, $mapA);
+            $this->assertEquals($key->get('a'), 1);
+
+            $this->assertEquals($value, $mapC);
+            $this->assertNotEquals($value, $mapB);
+            $this->assertEquals($value->get('b'), 2);
+        }
+    }
+
     // -=-= Data Providers =-=-
 
     /**


### PR DESCRIPTION
- Fixes #2
- Also fixes a failing test

Calling GetIterator originally converted itself to an array recursively
which causes any nested Maps to be converted to arrays as well. This is
not how an iterator should work. By using a generator we can return the
actual values without mutating them.

A side effect of this is that the new GetIterator method no longer
returns a "copy" of the Map. I can't see any downside of this since the
caller shouldn't be modifying an iterable inside a loop anyway.